### PR TITLE
Add check for empty DataFrame in invalid SQL test

### DIFF
--- a/tests/test_database_operations.py
+++ b/tests/test_database_operations.py
@@ -334,6 +334,7 @@ class TestErrorHandling:
         result = run_pass_through(invalid_query)
         assert isinstance(result, pd.DataFrame)
         # Should return empty DataFrame on error
+        assert result.empty
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- ensure `run_pass_through` returns an empty DataFrame when given invalid SQL

## Testing
- `pytest -q tests/test_database_operations.py::TestErrorHandling::test_invalid_sql_query_handling`

------
https://chatgpt.com/codex/tasks/task_b_6887948b330c832b910116c9c65d2704